### PR TITLE
Changed menu system in order that it appears integrated

### DIFF
--- a/MaximaOnAndroid/AndroidManifest.xml
+++ b/MaximaOnAndroid/AndroidManifest.xml
@@ -6,7 +6,7 @@
     android:versionName="1.6" >
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 	<uses-permission android:name="android.permission.INTERNET" />    
-    <uses-sdk android:minSdkVersion="8" android:targetSdkVersion="8" />
+    <uses-sdk android:minSdkVersion="8" android:targetSdkVersion="11"/>
 
     <application
         android:icon="@drawable/ic_launcher"
@@ -20,7 +20,7 @@
            	android:configChanges="keyboard|keyboardHidden|orientation">
         </activity>
         <activity android:name=".ManualActivity"
-            android:label="@string/app_name"
+            android:label="@string/manual_act_title"
            	android:configChanges="keyboard|keyboardHidden|orientation">
         </activity>
         <activity

--- a/MaximaOnAndroid/project.properties
+++ b/MaximaOnAndroid/project.properties
@@ -11,4 +11,4 @@
 #proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-project.txt
 
 # Project target.
-target=android-8
+target=android-11

--- a/MaximaOnAndroid/res/layout/main.xml
+++ b/MaximaOnAndroid/res/layout/main.xml
@@ -2,30 +2,25 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
-    android:orientation="vertical"
-    android:background="#FFFFFF" android:isScrollContainer="true">
+    android:isScrollContainer="true"
+    android:orientation="vertical" >
 
-    <ScrollView
-        android:id="@+id/scrollView1"
-        android:layout_width="match_parent"
+    <WebView
+        android:id="@+id/webView1"
+        android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:layout_weight="1"
-        android:isScrollContainer="true" >
-
-            <WebView
-                android:id="@+id/webView1"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:isScrollContainer="true" />
-
-    </ScrollView>
+        android:isScrollContainer="true" />
 
     <EditText
         android:id="@+id/editText1"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:ems="10"
+        android:layout_gravity="bottom"
         android:inputType="text"
-        android:maxLines="1" android:layout_gravity="bottom" android:isScrollContainer="false" android:keepScreenOn="true" android:selectAllOnFocus="true"/>
+        android:isScrollContainer="false"
+        android:keepScreenOn="true"
+        android:maxLines="1"
+        android:selectAllOnFocus="true" />
 
 </LinearLayout>

--- a/MaximaOnAndroid/res/menu/manmenu.xml
+++ b/MaximaOnAndroid/res/menu/manmenu.xml
@@ -1,6 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android" >
-    <item android:id="@+id/gomaxima" android:titleCondensed="Maxima" android:title="Back to Maxima"></item>
-    
+    <item
+        android:id="@+id/man_main"
+        android:icon="@android:drawable/ic_menu_preferences"
+        android:showAsAction="ifRoom|withText"
+        android:title="Language"
+        android:titleCondensed="Lan">
+        <menu>
+            <item
+                android:id="@+id/manual_en"
+                android:title="English"
+                android:titleCondensed="En">
+            </item>
+            <item
+                android:id="@+id/manual_jap"
+                android:title="Japanese"
+                android:titleCondensed="Jap">
+            </item>
+        </menu>
+    </item>
 
 </menu>

--- a/MaximaOnAndroid/res/menu/menu.xml
+++ b/MaximaOnAndroid/res/menu/menu.xml
@@ -1,10 +1,45 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android" >
-    <item android:id="@+id/about" android:titleCondensed="About MoA" android:title="About Maxima on Android"></item>
-    <item android:id="@+id/man" android:titleCondensed="Man" android:title="Manual"></item>
-    <item android:id="@+id/manj" android:titleCondensed="Man (J)" android:title="Manual (J)"></item>
-    <item android:id="@+id/graph" android:titleCondensed="Graph" android:title="Graph"></item>
-    <item android:id="@+id/quit" android:titleCondensed="Quit" android:title="Quit"></item>
-    
+
+    <item
+        android:id="@+id/about"
+        android:icon="@android:drawable/ic_menu_info_details"
+        android:title="About Maxima on Android"
+        android:titleCondensed="About MoA"
+        android:showAsAction="ifRoom|withText">
+    </item>
+    <item
+        android:id="@+id/man"
+        android:icon="@android:drawable/ic_menu_help"
+        android:title="Maxima Manual"
+        android:titleCondensed="Max Man"
+        android:showAsAction="ifRoom|withText">
+        <menu>
+            <item
+                android:id="@id/manual_en"
+                android:title="English"
+                android:titleCondensed="En">
+            </item>
+            <item
+                android:id="@id/manual_jap"
+                android:title="Japanese"
+                android:titleCondensed="Jap">
+            </item>
+        </menu>
+    </item>
+    <item
+        android:id="@+id/graph"
+        android:icon="@android:drawable/ic_menu_view"
+        android:title="Graph"
+        android:titleCondensed="Graph"
+        android:showAsAction="ifRoom|withText">
+    </item>
+    <item
+        android:id="@+id/quit"
+        android:icon="@android:drawable/ic_menu_close_clear_cancel"
+        android:title="Quit"
+        android:titleCondensed="Quit"
+        android:showAsAction="ifRoom|withText">
+    </item>
 
 </menu>

--- a/MaximaOnAndroid/res/values/strings.xml
+++ b/MaximaOnAndroid/res/values/strings.xml
@@ -3,5 +3,6 @@
 
     <string name="hello">Hello World, MaximaOnAndroidActivity!</string>
     <string name="app_name">MaximaOnAndroid</string>
+    <string name="manual_act_title">MaximaOnAndroid -- Maxima Manual</string>
 
 </resources>

--- a/MaximaOnAndroid/src/jp/yhonda/HTMLActivity.java
+++ b/MaximaOnAndroid/src/jp/yhonda/HTMLActivity.java
@@ -27,6 +27,12 @@ import android.webkit.WebViewClient;
 
 
 public class HTMLActivity extends Activity {
+  
+  /*
+   * Determines whether back button events are caught.
+   */
+  protected boolean interceptBackButton = true;
+  
 	public String urlonCreate=null;
     WebView webview=null;
 	
@@ -53,7 +59,7 @@ public class HTMLActivity extends Activity {
 
 	@Override
   public boolean onKeyDown( int keyCode, KeyEvent event ) {
-	  if ( event.getAction() == KeyEvent.ACTION_DOWN
+	  if ( interceptBackButton && event.getAction() == KeyEvent.ACTION_DOWN
 	          && keyCode == KeyEvent.KEYCODE_BACK
 	          && webview.canGoBack() == true ) {
 	      webview.goBack();

--- a/MaximaOnAndroid/src/jp/yhonda/ManualActivity.java
+++ b/MaximaOnAndroid/src/jp/yhonda/ManualActivity.java
@@ -18,25 +18,90 @@
 
 package jp.yhonda;
 
+import android.app.ActionBar;
+import android.app.Dialog;
+import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
+import android.os.Bundle;
 import android.preference.PreferenceManager;
+import android.text.method.HideReturnsTransformationMethod;
 import android.util.Log;
+import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
+import android.widget.Toast;
 
 public class ManualActivity extends HTMLActivity {
 	Context cont=this;
+	
+	ActionBar actionBar;
+	
+	public static final String LANGUAGE_EXTRA = "MANUAL_LANGUAGE_EXTRA";
+	public static final String ENGLISH_LOCATION_EXTRA = "ENGLISH_MANUAL_LOCATION_EXTRA";
+	public static final String JAPANESE_LOCATION_EXTRA = "JAPENESE_MANUAL_LOCATION_EXTRA";
+	
+	public static final int ENGLISH_VERSION = 10;
+	public static final int JAPANESE_VERSION = 11;
+	
+	public static final int LOADING_MANUAL_DIALOG_FLAG = 1993;
+	
+	private Bundle extras;
+	
+	private ProgressDialog loadingDialog;
+	
+	// Used to determine which version of the manual
+	// is being shown.
+	int languageFlag = ENGLISH_VERSION;
+	
+	@Override
+	public void onCreate(Bundle savedInstanceState) {
+    // Create the drop-down navigation for different manual
+    // languages. Needs to be called before super.onCreate to
+	  // set extras!
+    extras = getIntent().getExtras();
+    languageFlag = extras.getInt(LANGUAGE_EXTRA);
+    
+	  super.onCreate(savedInstanceState);
+	  interceptBackButton = false;
+	}
+	
+	@Override
+	public Dialog onCreateDialog(int id) {
+	  switch(id){
+	    case LOADING_MANUAL_DIALOG_FLAG:
+	      loadingDialog = new ProgressDialog(this);
+	      loadingDialog.setCancelable(true);
+	      loadingDialog.setTitle("Loading");
+	      loadingDialog.setIndeterminate(true);
+	      return loadingDialog;
+	  }
+	  return super.onCreateDialog(id);
+	}
+	
+	@Override
+	public void onPrepareDialog(int id, Dialog dialog) {
+	  switch(id){
+	    case LOADING_MANUAL_DIALOG_FLAG:
+	      switch(languageFlag){
+	        case ENGLISH_VERSION: loadingDialog.setMessage("Loading English version..."); break;
+	        default: loadingDialog.setMessage("Loading Japanese version..."); break;
+	      }
+	  }
+	}
+	
 	private class CustomWebView extends WebViewClient {
-		//ページの読み込み完了
+		//ﾂペﾂーﾂジﾂづ個禿�ﾂづ敖債楪づ敖環ｮﾂ猟ｹ
 		@Override
 		public void onPageFinished(WebView view, String url) {
 			Log.v("man","onPageFinished");
+			if(loadingDialog != null && loadingDialog.isShowing())
+			  dismissDialog(LOADING_MANUAL_DIALOG_FLAG);
 			SharedPreferences pref=PreferenceManager.getDefaultSharedPreferences(cont);
 			String targetURL=pref.getString("url", "");
 			if (!targetURL.equals(url)) return;
@@ -65,7 +130,16 @@ public class ManualActivity extends HTMLActivity {
 			webview.setInitialScale(sc);
 			webview.loadUrl(url);
 		} else {
-			super.loadURLonCreate();
+		  switch(languageFlag) {
+		    case ENGLISH_VERSION:
+		      getIntent().putExtra("url", extras.getString(ENGLISH_LOCATION_EXTRA));
+		      break;
+		    default:
+		      getIntent().putExtra("url", extras.getString(JAPANESE_LOCATION_EXTRA));
+		      break;
+		  }
+		  showDialog(LOADING_MANUAL_DIALOG_FLAG);
+		  super.loadURLonCreate();
 		}
 		
 	}
@@ -81,6 +155,9 @@ public class ManualActivity extends HTMLActivity {
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
 	  switch (item.getItemId()) {
+	    /* Removed. The ManualActivity now behaves like
+	     * a traditional Android activity: the back button
+	     * is used to navigate back up the stack.
 	  case R.id.gomaxima:
 		  float scale=webview.getScale();
 		  String url=webview.getUrl();
@@ -101,6 +178,19 @@ public class ManualActivity extends HTMLActivity {
 
 
 		  return true;
+		  */
+	  case R.id.manual_en:
+        if (languageFlag != ENGLISH_VERSION) {
+          languageFlag = ENGLISH_VERSION;
+          loadURLonCreate();
+        }
+	    return true;
+	  case R.id.manual_jap:
+        if (languageFlag != JAPANESE_VERSION) {
+          languageFlag = JAPANESE_VERSION;
+          loadURLonCreate();
+        }
+	    return true;
 	  default:
 		  return super.onOptionsItemSelected(item);
 	  }

--- a/MaximaOnAndroid/src/jp/yhonda/MaximaOnAndroidActivity.java
+++ b/MaximaOnAndroid/src/jp/yhonda/MaximaOnAndroidActivity.java
@@ -52,7 +52,6 @@ public class MaximaOnAndroidActivity extends Activity implements TextView.OnEdit
 	Semaphore sem = new Semaphore(1);
 	EditText _editText;
     WebView webview;
-    ScrollView scview;
     CommandExec maximaProccess;
     File internalDir;
     File externalDir;
@@ -77,12 +76,12 @@ public class MaximaOnAndroidActivity extends Activity implements TextView.OnEdit
 		  case R.id.quit:
 			  exitMOA();
 			  return true;
-		  case R.id.man:
-			  showManual("file://"+internalDir+"/additions/en/maxima.html");
+		  case R.id.manual_en:
+			  showManual("file://"+internalDir+"/additions/en/maxima.html", ManualActivity.ENGLISH_VERSION);
 			  return true;
-		  case R.id.manj:
-			  showManual("file://"+internalDir+"/additions/ja/maxima.html");
-			  return true;
+		  case R.id.manual_jap:
+		    showManual("file://"+internalDir+"/additions/ja/maxima.html", ManualActivity.JAPANESE_VERSION);
+		    return true;
 		  default:
 			   return super.onOptionsItemSelected(item);
 		  }
@@ -101,7 +100,6 @@ public class MaximaOnAndroidActivity extends Activity implements TextView.OnEdit
         webview.getSettings().setJavaScriptEnabled(true); 
         webview.setWebViewClient(new WebViewClient() {}); 
         webview.getSettings().setBuiltInZoomControls(true);
-        scview = (ScrollView) findViewById(R.id.scrollView1);
         
         if (Build.VERSION.SDK_INT > 16) { // > JELLY_BEAN
         	maximaURL=newmaximaURL;
@@ -136,7 +134,7 @@ public class MaximaOnAndroidActivity extends Activity implements TextView.OnEdit
        				startMaxima();
        			}
        		}).start();
-       	}   		
+       	}   	
     }
     
     
@@ -172,7 +170,7 @@ public class MaximaOnAndroidActivity extends Activity implements TextView.OnEdit
     	try {
 			sem.acquire();
 		} catch (InterruptedException e1) {
-			// TODO ©“®¶¬‚³‚ê‚½ catch ƒuƒƒbƒN
+			// TODO ÂÂ©Â“Â®ÂÂ¶ÂÂ¬Â‚Â³Â‚ÃªÂ‚Â½ catch ÂƒuÂƒÂÂƒbÂƒN
 			e1.printStackTrace();
 		}
     	if ( ! ( new File( internalDir+"/maxima-"+mvers.versionString() ) ).exists() &&
@@ -187,7 +185,7 @@ public class MaximaOnAndroidActivity extends Activity implements TextView.OnEdit
         try {
             maximaProccess.execCommand(list);
         } catch (Exception e) {
-            // —áŠOˆ—
+            // Â—Ã¡ÂŠOÂÂˆÂ—Â
         }
         maximaProccess.clearStringBuilder();
         sem.release();
@@ -204,11 +202,11 @@ public class MaximaOnAndroidActivity extends Activity implements TextView.OnEdit
 				Runnable viewtask = new Runnable() {
 					@Override
 					public void run() {
-						scview.fullScroll(ScrollView.FOCUS_DOWN);
+					  webview.pageDown(true);
 						Log.v("My Test","scroll!");
 					}
 				};
-				scview.post(viewtask);
+				webview.post(viewtask);
 			}
     	};
     	handler.postDelayed(task, 1000);
@@ -218,7 +216,7 @@ public class MaximaOnAndroidActivity extends Activity implements TextView.OnEdit
    		try {
 			sem.acquire();
 		} catch (InterruptedException e1) {
-			// TODO ©“®¶¬‚³‚ê‚½ catch ƒuƒƒbƒN
+			// TODO ÂÂ©Â“Â®ÂÂ¶ÂÂ¬Â‚Â³Â‚ÃªÂ‚Â½ catch ÂƒuÂƒÂÂƒbÂƒN
 			e1.printStackTrace();
 		}
    		sem.release();
@@ -249,10 +247,10 @@ public class MaximaOnAndroidActivity extends Activity implements TextView.OnEdit
    					return false;
    				}
 			} catch (IOException e) {
-				// TODO ©“®¶¬‚³‚ê‚½ catch ƒuƒƒbƒN
+				// TODO ÂÂ©Â“Â®ÂÂ¶ÂÂ¬Â‚Â³Â‚ÃªÂ‚Â½ catch ÂƒuÂƒÂÂƒbÂƒN
 				e.printStackTrace();
 			} catch (Exception e) {
-				// TODO ©“®¶¬‚³‚ê‚½ catch ƒuƒƒbƒN
+				// TODO ÂÂ©Â“Â®ÂÂ¶ÂÂ¬Â‚Â³Â‚ÃªÂ‚Â½ catch ÂƒuÂƒÂÂƒbÂƒN
 				e.printStackTrace();
 			}
 
@@ -289,7 +287,7 @@ public class MaximaOnAndroidActivity extends Activity implements TextView.OnEdit
 		        try {
 		        	gnuplotcom.execCommand(list);
 		        } catch (Exception e) {
-		            // —áŠOˆ—
+		            // Â—Ã¡ÂŠOÂÂˆÂ—Â
 		        }
 		        if ((new File("/data/data/jp.yhonda/files/maxout.html")).exists()) {
 		        	showHTML("file:///data/data/jp.yhonda/files/maxout.html");
@@ -302,7 +300,7 @@ public class MaximaOnAndroidActivity extends Activity implements TextView.OnEdit
 		        try {
 		        	qepcadcom.execCommand(list);
 		        } catch (Exception e) {
-		            // —áŠOˆ—
+		            // Â—Ã¡ÂŠOÂÂˆÂ—Â
 		        }
 				
 			}
@@ -313,7 +311,7 @@ public class MaximaOnAndroidActivity extends Activity implements TextView.OnEdit
    	}
    	
    	private boolean maxima_syntax_check(String cmd) {
-   		// ÅŒã‚ªƒZƒ~ƒRƒƒ“‚ ‚é‚¢‚Íƒ_ƒ‰[‚ÅI‚í‚Á‚Ä‚¢‚é‚©ƒ`ƒFƒbƒN
+   		// ÂÃ…ÂŒÃ£Â‚ÂªÂƒZÂƒ~ÂƒRÂƒÂÂƒÂ“Â‚Â Â‚Ã©Â‚Â¢Â‚ÃÂƒ_ÂƒÂ‰Â[Â‚Ã…ÂIÂ‚Ã­Â‚ÃÂ‚Ã„Â‚Â¢Â‚Ã©Â‚Â©Âƒ`ÂƒFÂƒbÂƒN
    		if (!cmd.endsWith(";") && !cmd.endsWith("$")) return false;
    		if (cmd.endsWith(";;")) return false;
    		return true;
@@ -324,21 +322,21 @@ public class MaximaOnAndroidActivity extends Activity implements TextView.OnEdit
    	}
    	
    	static private String substitute(String input, String pattern, String replacement) {
-   	    // ’uŠ·‘ÎÛ•¶š—ñ‚ª‘¶İ‚·‚éêŠ‚ğæ“¾
+   	    // Â’uÂŠÂ·Â‘ÃÂÃ›Â•Â¶ÂÂšÂ—Ã±Â‚ÂªÂ‘Â¶ÂÃÂ‚Â·Â‚Ã©ÂÃªÂÂŠÂ‚Ã°ÂÃ¦Â“Â¾
    	    int index = input.indexOf(pattern);
 
-   	    // ’uŠ·‘ÎÛ•¶š—ñ‚ª‘¶İ‚µ‚È‚¯‚ê‚ÎI—¹
+   	    // Â’uÂŠÂ·Â‘ÃÂÃ›Â•Â¶ÂÂšÂ—Ã±Â‚ÂªÂ‘Â¶ÂÃÂ‚ÂµÂ‚ÃˆÂ‚Â¯Â‚ÃªÂ‚ÃÂIÂ—Â¹
    	    if(index == -1) {
    	        return input;
    	    }
 
-   	    // ˆ—‚ğs‚¤‚½‚ß‚Ì StringBuffer
+   	    // ÂÂˆÂ—ÂÂ‚Ã°ÂsÂ‚Â¤Â‚Â½Â‚ÃŸÂ‚ÃŒ StringBuffer
    	    StringBuffer buffer = new StringBuffer();
 
    	    buffer.append(input.substring(0, index) + replacement);
 
    	    if(index + pattern.length() < input.length()) {
-   	        // c‚è‚Ì•¶š—ñ‚ğÄ‹A“I‚É’uŠ·
+   	        // ÂcÂ‚Ã¨Â‚ÃŒÂ•Â¶ÂÂšÂ—Ã±Â‚Ã°ÂÃ„Â‹AÂ“IÂ‚Ã‰Â’uÂŠÂ·
    	        String rest = input.substring(index + pattern.length(), input.length());
    	        buffer.append(substitute(rest, pattern, replacement));
    	    }
@@ -351,11 +349,27 @@ public class MaximaOnAndroidActivity extends Activity implements TextView.OnEdit
       	intent.putExtra("url", url);
       	this.startActivity(intent);
    	}
-   	private void showManual(String url) {
+
+   	/**
+   	 * 
+   	 * @param url
+   	 * @param languageFlag Should be one of 
+   	 * {@link jp.yhonda.ManualActivity.ENGLISH_VERSION} or
+   	 * {@link jp.yhonda.ManualActivity.JAPANESE_VERSION} to indicate
+   	 * which manual language version should be displayed.
+   	 */
+   	private void showManual(String url, int languageFlag) {
       	Intent intent = new Intent(this,ManualActivity.class);
       	intent.setAction(Intent.ACTION_VIEW);
       	intent.putExtra("url", url);
       	intent.putExtra("dir", internalDir);
+      	intent.putExtra(ManualActivity.LANGUAGE_EXTRA, languageFlag);
+      	
+      	// The design seems to be that ManualActivity doesn't know
+      	// the locations of the manual files; so they are passed here
+      	// for lanuage switching within ManualActivity.
+      	intent.putExtra(ManualActivity.ENGLISH_LOCATION_EXTRA, "file://"+internalDir+"/additions/en/maxima.html");
+      	intent.putExtra(ManualActivity.JAPANESE_LOCATION_EXTRA, "file://"+internalDir+"/additions/ja/maxima.html");
       	this.startActivity(intent);
    	}   	
    	private void showGraph() {
@@ -394,10 +408,10 @@ public class MaximaOnAndroidActivity extends Activity implements TextView.OnEdit
 			maximaProccess.maximaCmd("quit();\n");
 			finish();
 		} catch (IOException e) {
-			// TODO ©“®¶¬‚³‚ê‚½ catch ƒuƒƒbƒN
+			// TODO ÂÂ©Â“Â®ÂÂ¶ÂÂ¬Â‚Â³Â‚ÃªÂ‚Â½ catch ÂƒuÂƒÂÂƒbÂƒN
 			e.printStackTrace();
 		} catch (Exception e) {
-			// TODO ©“®¶¬‚³‚ê‚½ catch ƒuƒƒbƒN
+			// TODO ÂÂ©Â“Â®ÂÂ¶ÂÂ¬Â‚Â³Â‚ÃªÂ‚Â½ catch ÂƒuÂƒÂÂƒbÂƒN
 			e.printStackTrace();
 		}
    	}


### PR DESCRIPTION
Various changes throughout the code have been made so that the menu system integrates as expected on Android 3.0+ devices but still will use the menu button on older Android devices.

The manual was changed so that the Android back button is used.

I think I have fixed my Eclipse setup for Japanese characters, but GitHub is showing that the comments in Japanese are changed with my pull request. When I compare the files on my computer though with a comparison tool (Meld for example), the files are identical; therefore, is there a problem with GitHub?
